### PR TITLE
check-kube-service-available able to check all services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- check-kube-service-available.rb: Allow checking of all services by default. Services without a selector will be checked for an  endpoint.
 
 ## [0.1.0] - 2016-05-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Usage: check-kube-service-available.rb (options)
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
     -p, --pending SECONDS            Time (in seconds) a pod may be pending for and be valid
-    -l, --list SERVICES              List of services to check (required)
+    -l, --list SERVICES              List of services to check. Defaults to 'all'
 ```
 
 **check-kube-pods-runtime.rb**


### PR DESCRIPTION
## Pull Request Checklist

For issue #17 
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [?] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Updated check-kube-service-available script allows checking all services in the cluster without having to specify the service list. (Thus not requiring config change/etc when services change)
#### Known Issue

May return false positives for a service if the backend pod(s) are Ready but failing readiness probes.
