### PR TITLE
cli.rb: fixed typo in critical call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- cli.rb: Fixed typo in critical call
+
 ## [0.1.0] - 2016-05-15
 ### Added
 - Added flag to ignore namespaces in check-kube-pods-pending

--- a/lib/sensu-plugins-kubernetes/cli.rb
+++ b/lib/sensu-plugins-kubernetes/cli.rb
@@ -87,7 +87,7 @@ module Sensu
               token_file: config[:api_token_file]
             )
           rescue ArgumentError => e
-            critial e.message
+            critical e.message
           end
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Fixed typo in cli.rb calling the critical method when an argument error occurs initializing the kubernetes client.