### PR TITLE
include namespace for check-kube-pods-pending.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [0.1.2] - 2016-05-27
 ### Changed
 - check-kube-pods-pending.rb: Add namespace to output
+- check-kube-service-available.rb: Add namespace to output
 
 ## [0.1.1] - 2016-05-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.1.2] - 2016-05-27
+### Changed
+- check-kube-pods-pending.rb: Add namespace to output
+
 ## [0.1.1] - 2016-05-17
 ### Fixed
 - cli.rb: Fixed typo in critical call

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -1,3 +1,4 @@
+
 #! /usr/bin/env ruby
 #
 #   check-kube-pods-pending
@@ -104,14 +105,14 @@ class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
       if pod.status.phase == 'Pending'
         pod_stamp = Time.parse(pod.metadata.creationTimestamp)
         if (Time.now.utc - pod_stamp.utc).to_i > config[:pending_timeout]
-          failed_pods << pod.metadata.name
+          failed_pods << "#{pod.metadata.namespace}.#{pod.metadata.name}"
         end
       end
       # Check restarts
       next if pod.status.containerStatuses.nil?
       pod.status.containerStatuses.each do |container|
         if container.restartCount.to_i > config[:restart_count]
-          restarted_pods << container.name
+          restarted_pods << "#{pod.metadata.namespace}.#{container.name}"
         end
       end
     end

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env ruby
 #
 #   check-kube-pods-pending

--- a/bin/check-kube-service-available.rb
+++ b/bin/check-kube-service-available.rb
@@ -96,7 +96,7 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
             break if pod_available
           end
         end
-        failed_services << p.metadata.name if pod_available == false
+        failed_services << "#{p.metadata.namespace}.#{p.metadata.name}" if pod_available == false
       end
     end
 

--- a/lib/sensu-plugins-kubernetes/version.rb
+++ b/lib/sensu-plugins-kubernetes/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsKubernetes
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
fixes #20 
adds namespaces to check-kube-pods-pending.rb

output before:
```
AllPodsAreReady CRITICAL: Pods exceeded restart threshold: aviary-eagle-web aviary-falcon-web aviary-falcon-web content-service content-service aviary-eagle-web content-service

```
output after
```
AllPodsAreReady CRITICAL: Pods exceeded restart threshold: jenkins-aviary-eagle-web-staging.aviary-eagle-web jenkins-aviary-falcon-web-kuberning.aviary-falcon-web jenkins-aviary-falcon-web-ta-1245.aviary-falcon-web jenkins-content-service-development.content-service jenkins-content-service-test-s3.content-service jenkins-staging.aviary-eagle-web jenkins-test-content-service.content-service

```

