### PR TITLE
Split up check-kube-pods-pending into two checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Added metrics-pods.rb that will output the number of running pods per service
 - Added check-kube-pods-running check
+- Split check-kube-pods-pending into two checks; the original still checks for
+pending pods, the restart count portion has been split into it's own check.
 
 ## [0.1.2] - 2016-08-07
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This provides functionality to check node and pod status as well as api and serv
 - bin/check-kube-service-available.rb
 - bin/check-kube-pods-runtime.rb
 - bin/check-kube-pods-running.rb
+- bin/check-kube-pods-restarting.rb
 - bin/handler-kube-pod.rb
 - bin/metrics-pods.rb
 
@@ -124,6 +125,27 @@ Usage: ./check-kube-pods-running.rb (options)
         --exclude-namespace
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
+```
+
+**check-kube-pods-restarting.rb**
+
+```
+Usage: ./check-kube-pods-restarting.rb (options)
+        --ca-file CA-FILE            CA file to verify API server cert
+        --cert CERT-FILE             Client cert to present
+        --key KEY-FILE               Client key for the client cert
+        --in-cluster                 Use service account authentication
+        --password PASSWORD          If user is passed, also pass a password
+    -s, --api-server URL             URL to API server
+    -t, --token TOKEN                Bearer token for authorization
+        --token-file TOKEN-FILE      File containing bearer token for authorization
+    -u, --user USER                  User with access to API
+    -v, --api-version VERSION        API version
+    -n NAMESPACES,                   Exclude the specified list of namespaces
+        --exclude-namespace
+    -f, --filter FILTER              Selector filter for pods to be checked
+    -p, --pods PODS                  List of pods to check
+    -r, --restart COUNT              Threshold for number of restarts allowed
 ```
 
 **handler-kube-pod.rb**


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yup. #25 

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose
Split up the pod-pending check into two, one for just looking for pending pods, and another that checks the restart count on pods.

#### Known Compatablity Issues
None

