### PR TITLE
ugprade kubeclient to 2.3.0

### DIFF
--- a/sensu-plugins-kubernetes.gemspec
+++ b/sensu-plugins-kubernetes.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsKubernetes::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
-  s.add_runtime_dependency 'kubeclient',     '1.1.3'
+  s.add_runtime_dependency 'kubeclient',     '~> 2.3'
   s.add_runtime_dependency 'activesupport',  '< 5.0.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
#### Purpose

Upgrade kubeclient to 2.3.0 so deployments and other new resources are supported

#### Known Compatablity Issues

None yet
