### PR TITLE
Add support for kubeconfig file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
+- Add option to use kubeconfig file for auth and TLS (@jaxxstorm)
 
 ## [1.0.0] - 2017-03-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Usage: check-kube-nodes-ready.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-apiserver-available.rb**
@@ -49,6 +50,7 @@ Usage: check-kube-apiserver-available.rb (options)
     -t, --token TOKEN                Bearer token for authorization
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-pods-pending.rb**
@@ -70,6 +72,7 @@ Usage: check-kube-pods-pending.rb (options)
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
     -r, --restart COUNT              Threshold for number of restarts allowed
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-service-available.rb**
@@ -87,6 +90,7 @@ Usage: check-kube-service-available.rb (options)
     -v, --api-version VERSION        API version
     -p, --pending SECONDS            Time (in seconds) a pod may be pending for and be valid
     -l, --list SERVICES              List of services to check (required)
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-pods-runtime.rb**
@@ -106,6 +110,7 @@ Usage: check-kube-pods-runtime.rb (options)
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
     -w, --warn TIMEOUT               Threshold for pods to be in the pending state
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-pods-running.rb**
@@ -125,6 +130,7 @@ Usage: ./check-kube-pods-running.rb (options)
         --exclude-namespace
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **check-kube-pods-restarting.rb**
@@ -146,6 +152,7 @@ Usage: ./check-kube-pods-restarting.rb (options)
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
     -r, --restart COUNT              Threshold for number of restarts allowed
+        --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 **handler-kube-pod.rb**
@@ -186,6 +193,7 @@ Usage: metrics-pods.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
         -u, --user USER                  User with access to API
         -v, --api-version VERSION        API version
+            --kube-config KUBECONFIG     Path to a kube config file
 ```
 
 `api_server` and `api_version` can still be used for backwards compatibility,
@@ -209,6 +217,7 @@ Of the Kubernetes connection options:
 --password PASSWORD          If user is passed, also pass a password
 --token TOKEN                Bearer token for authorization
 --token-file TOKEN-FILE      File containing bearer token for authorization
+--kube-config KUBECONFIG     Path to a kube config file
 ```
 Only the API server option is required, however it does default to the `KUBERNETES_MASTER` environment variable, or you can use the in-cluster option. The other options are to be used as needed.
 

--- a/README.md
+++ b/README.md
@@ -236,3 +236,5 @@ Only one of the authentication methods (user, token, or token file) can be used.
 For example, using a username and a token, or a token and a token file, will produce an error.
 
 If the 'user' authentication method is used, a password must also be provided.
+
+The kubeconfig options enable the usage of a kubeconfig file, which is a yaml file which defines the authentication and TLS config. More information about kubeconfig files can be found in the [Kubernetes Docs](https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/)

--- a/lib/sensu-plugins-kubernetes/cli.rb
+++ b/lib/sensu-plugins-kubernetes/cli.rb
@@ -66,6 +66,11 @@ module Sensu
                long: '--token-file TOKEN-FILE',
                default: nil
 
+        option :kube_config,
+               description: 'Path to a kube config file',
+               long: '--kube-config KUBECONFIG',
+               default: nil
+
         attr_reader :client
 
         # Initializes the Sensu check by creating a Kubernetes client
@@ -84,7 +89,8 @@ module Sensu
               username: config[:api_user],
               password: config[:api_password],
               token: config[:api_token],
-              token_file: config[:api_token_file]
+              token_file: config[:api_token_file],
+              kube_config: config[:kube_config]
             )
           rescue ArgumentError => e
             critical e.message


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Instead of having to pass a full list of options to the plugins, you can now specify a kubeconfig file.

Example:

```
bundle exec bin/check-kube-nodes-ready.rb --kube-config ~/.kube/config
AllNodesAreReady CRITICAL: Nodes are not ready: <redacted> <redacted>
```