### PR TITLE
add check-kube-service-endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Add `check-kube-service-endpoints.rb` check (@joemiller)
 
 ## [1.1.0] - 2017-08-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This provides functionality to check node and pod status as well as api and serv
 - bin/check-kube-apiserver-available.rb
 - bin/check-kube-pods-pending.rb
 - bin/check-kube-service-available.rb
+- bin/check-kube-service-endpoints.rb
 - bin/check-kube-pods-runtime.rb
 - bin/check-kube-pods-running.rb
 - bin/check-kube-pods-restarting.rb
@@ -91,6 +92,27 @@ Usage: check-kube-service-available.rb (options)
     -p, --pending SECONDS            Time (in seconds) a pod may be pending for and be valid
     -l, --list SERVICES              List of services to check (required)
         --kube-config KUBECONFIG     Path to a kube config file
+```
+
+**check-kube-service-endpoints.rb**
+```
+Usage: bin/check-kube-service-endpoints.rb (options)
+        --ca-file CA-FILE            CA file to verify API server cert
+        --cert CERT-FILE             Client cert to present
+        --key KEY-FILE               Client key for the client cert
+        --in-cluster                 Use service account authentication
+    -p, --password PASSWORD          If user is passed, also pass a password
+    -s, --api-server URL             URL to API server
+        --token TOKEN                Bearer token for authorization
+        --token-file TOKEN-FILE      File containing bearer token for authorization
+    -u, --user USER                  User with access to API
+        --api-version VERSION        API version
+        --exclude-namespaces         Exclude the specified list of namespaces
+        --exclude-services           comma separated list of services to exclude
+    -n, --namespaces NAMESPACES      comma separated list of namespaces to check (default all)
+    -l, --services SERVICES          comma separated list of services to check (default all)
+    -t, --types TYPES                comma separated list of service types to check (default: ClusterIP,LoadBalancer)
+    -v, --verbose                    verbose output
 ```
 
 **check-kube-pods-runtime.rb**

--- a/bin/check-kube-service-endpoints.rb
+++ b/bin/check-kube-service-endpoints.rb
@@ -1,0 +1,128 @@
+#! /usr/bin/env ruby
+#
+#   check-kube-service-endpoints
+#
+# DESCRIPTION:
+# => Check if your kube services are available to serve traffic by checking for services with empty endpoints.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: kube-client
+#
+# USAGE:
+#     --ca-file CA-FILE            CA file to verify API server cert
+#     --cert CERT-FILE             Client cert to present
+#     --key KEY-FILE               Client key for the client cert
+#     --in-cluster                 Use service account authentication
+# -p, --password PASSWORD          If user is passed, also pass a password
+# -s, --api-server URL             URL to API server
+#     --token TOKEN                Bearer token for authorization
+#     --token-file TOKEN-FILE      File containing bearer token for authorization
+# -u, --user USER                  User with access to API
+#     --api-version VERSION        API version
+#     --exclude-namespaces         Exclude the specified list of namespaces
+#     --exclude-services           comma separated list of services to exclude
+# -n, --namespaces NAMESPACES      comma separated list of namespaces to check (default all)
+# -l, --services SERVICES          comma separated list of services to check (default all)
+# -t, --types TYPES                comma separated list of service types to check (default: ClusterIP,LoadBalancer)
+# -v, --verbose                    verbose output
+#
+# NOTES:
+#
+# LICENSE:
+#   Joe Miller <joeym@joey.net>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-kubernetes/cli'
+
+class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
+  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+
+  option :service_list,
+         description: 'comma separated list of services to check (default all)',
+         short: '-l SERVICES',
+         long: '--services',
+         proc: proc { |a| a.split(',') },
+         default: 'all'
+
+  option :exclude_services,
+         description: 'comma separated list of services to exclude',
+         long: '--exclude-services',
+         proc: proc { |a| a.split(',') },
+         default: 'all'
+
+  option :namespaces,
+         description: 'comma separated list of namespaces to check (default all)',
+         short: '-n NAMESPACES',
+         long: '--namespaces',
+         proc: proc { |a| a.split(',') },
+         default: 'all'
+
+  option :exclude_namespace,
+         description: 'Exclude the specified list of namespaces',
+         long: '--exclude-namespaces',
+         proc: proc { |a| a.split(',') },
+         default: ''
+
+  option :service_types,
+         description: 'comma separated list of service types to check (default: ClusterIP,LoadBalancer)',
+         short: '-t TYPES',
+         long: '--types',
+         proc: proc { |a| a.downcase.split(',') },
+         default: %w(clusterip loadbalancer)
+
+  option :verbose,
+         description: 'verbose output',
+         short: '-v',
+         long: '--verbose',
+         boolean: true,
+         default: false
+
+  def run
+    puts "config: #{config.inspect}" if config[:verbose]
+    failed_services = []
+
+    services = client.get_services
+    services.each do |s|
+      # namespace whitelist / blacklisting
+      next if config[:exclude_namespace].include?(s.metadata.namespace)
+      next unless config[:namespaces].include?(s.metadata.namespace) || config[:namespaces].include?('all')
+
+      # filter service types
+      next unless config[:service_types].include?(s.spec.type.downcase)
+
+      # service whitelist / blacklisting
+      next if config[:exclude_services].include?(s.metadata.name)
+      next unless config[:service_list].include?(s.metadata.name) || config[:service_list].include?('all')
+
+      puts "#{s.metadata.namespace} #{s.metadata.name} #{s.spec.type}" if config[:verbose]
+
+      begin
+        ep = client.get_endpoint(s.metadata.name, s.metadata.namespace)
+      rescue
+        puts "#{s.metadata.name} couldn't find matching endpoint" if config[:verbose]
+        next
+      end
+
+      if ep.subsets.empty?
+        failed_services << format('%s/%s', s.metadata.namespace, s.metadata.name)
+      end
+    end
+
+    if failed_services.empty?
+      ok 'All services are available'
+    else
+      critical "Services unavailable: #{failed_services.join("\n")}"
+    end
+  rescue KubeException => e
+    critical 'API error: ' << e.message
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

This adds a new check: `check-kube-service-endpoints.rb`. It is conceptually similar to the existing `check-kube-service-available.rb` check except:

- Unlike `check-kube-service-available.rb` which requires a `--list` of services, this checks all services by default. Use `--namespaces`, `--exclude-namespaces`, `--services`, `--exclude-services` to construct a smaller list using either a whitelist or blacklist approach.

- Unlike `check-kube-service-available.rb` which checks for pods behind a service to be in a `Running` state, it checks that the Endpoint backing a Service has at least 1 address registered.
This seems to be the better way to check for service availability. For example, a pod may be in the 'Running' state but failing its readiness probe thus it will not actually be able to service requests. The Kubernetes docs (https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/) indicate that each Service will have an Endpoint matching the name of the Service. When there are pods available and ready to service traffic they are added to the Endpoint. The Service routes to the Endpoint. So when the Endpoint object is empty it can be declared that the associated Service is unavailable. 

Only Services of type `ClusterIP` and `LoadBalancer` are checked. This avoids checkins special service types like `ExternalName` which are not expected to have Endpoints containing registered IPs


#### Known Compatibility Issues

I would like some feedback on how to name the check due to the conceptual overlap with the `check-kube-service-available.rb` check. Is it OK to simply leave it as is - named `check-kube-service-endpoints.rb` - and update the README to call out the different approach for checking service health - or is there a better suggestion for a name? Or should it even replace the current `check-kube-service-available.rb` check? (I think it should but understand that there are existing users and use cases to consider.)

