### PR TITLE
Adds ability to explicitly include namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
  - Add option to explicitly include specific namespaces (@simulalex)
-### Removed
+### Breaking Change
  - Drops support for Ruby-2.0, now requires Ruby >= 2.1.0 (@simulalex)
 
 ## [1.1.0] - 2017-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
  - Add option to explicitly include specific namespaces (@simulalex)
+### Removed
+ - Drops support for Ruby-2.0, now requires Ruby >= 2.1.0 (@simulalex)
 
 ## [1.1.0] - 2017-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+ - Add option to explicitly include specific namespaces (@simulalex)
 
 ## [1.1.0] - 2017-08-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Usage: check-kube-pods-pending.rb (options)
     -v, --api-version VERSION        API version
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
+    -i NAMESPACES,                   Include the specified list of namespaces, an 
+        --include-namespace          empty list includes all namespaces
     -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
@@ -128,6 +130,8 @@ Usage: ./check-kube-pods-running.rb (options)
     -v, --api-version VERSION        API version
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
+    -i NAMESPACES,                   Include the specified list of namespaces, an 
+        --include-namespace          empty list includes all namespaces
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
         --kube-config KUBECONFIG     Path to a kube config file
@@ -149,6 +153,8 @@ Usage: ./check-kube-pods-restarting.rb (options)
     -v, --api-version VERSION        API version
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
+    -i NAMESPACES,                   Include the specified list of namespaces, an 
+        --include-namespace          empty list includes all namespaces
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
     -r, --restart COUNT              Threshold for number of restarts allowed

--- a/sensu-plugins-kubernetes.gemspec
+++ b/sensu-plugins-kubernetes.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   s.summary                = 'Sensu plugins for kubernetes'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsKubernetes::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Adds the ability to explicitly include namespaces (rather than just excluding them) in check-kube-pods-pending/restarting/running. This is useful in situations where (for example) changes to a feature branch are deployed to their own, individual namespace. In that case we're only really interested in monitoring the health of pods deployed to the "master" or "pre-production" namespaces and not those in the "my-work-in-progress" namespace.

#### Known Compatibility Issues
This change will remove support for Ruby 2.0, requiring >= Ruby 2.1