### PR TITLE
Don't trigger alert on node if it is set as unschedulable. Fixes #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Change
+ - check-kube-nodes-ready.rb no longer triggers an alert if an unschedulable node becomes NotReady (@tg90nor)
 
 ## [2.0.0] - 2017-08-28
 ### Added

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -45,7 +45,7 @@ class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
       if item.nil?
         warning "#{node.name} does not have a status"
       elsif item.status != 'True'
-        failed_nodes << node.metadata.name
+        failed_nodes << node.metadata.name unless node.spec.unschedulable
       end
     end
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes, #38

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Avoids triggering an alert in check-kube-nodes-ready.rb if a node is set as unschedulable.
This allows one to perform maintenance on a kubernetes cluster without triggering the alert.

#### Known Compatibility Issues

