### PR TITLE
Add option to explicitly include or exclude specific nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+ - Add option to explicitly include or exclude specific nodes (@ttarczynski)
 
 ### Fixed
 - check-kube-pods-running.rb no longer throws an exception when there are no 3 conditions in the status information. Issue #39 (@AgarFu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-### Changed
- - Add option to explicitly include or exclude specific nodes (@ttarczynski)
+### Added
+ - `check-kube-nodes-ready.rb`, `check-kube-pods-pending.rb`, `check-kube-pods-restarting.rb`, `check-kube-pods-running.rb`: added options `--included-nodes` and `--excluded-nodes` which support a comma separated list so you can filter nodes (@ttarczynski)
 
 ### Fixed
 - check-kube-pods-running.rb no longer throws an exception when there are no 3 conditions in the status information. Issue #39 (@AgarFu)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Usage: check-kube-nodes-ready.rb (options)
     -v, --api-version VERSION        API version
         --kube-config KUBECONFIG     Path to a kube config file
         --exclude-nodes              Exclude the specified nodes (comma separated list)
+                                     Exclude wins when a node is in both include and exclude lists
         --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
 ```
@@ -74,6 +75,7 @@ Usage: check-kube-pods-pending.rb (options)
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
         --exclude-nodes              Exclude the specified nodes (comma separated list)
+                                     Exclude wins when a node is in both include and exclude lists
         --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
@@ -139,6 +141,7 @@ Usage: ./check-kube-pods-running.rb (options)
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
         --exclude-nodes              Exclude the specified nodes (comma separated list)
+                                     Exclude wins when a node is in both include and exclude lists
         --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked
@@ -165,6 +168,7 @@ Usage: ./check-kube-pods-restarting.rb (options)
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
         --exclude-nodes              Exclude the specified nodes (comma separated list)
+                                     Exclude wins when a node is in both include and exclude lists
         --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Usage: check-kube-nodes-ready.rb (options)
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
         --kube-config KUBECONFIG     Path to a kube config file
-        --exclude-node               Exclude the specified list of nodes
-        --include-node               Include the specified list of nodes, an
+        --exclude-nodes              Exclude the specified nodes (comma separated list)
+        --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
 ```
 
@@ -73,8 +73,8 @@ Usage: check-kube-pods-pending.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
-        --exclude-node               Exclude the specified list of nodes
-        --include-node               Include the specified list of nodes, an
+        --exclude-nodes              Exclude the specified nodes (comma separated list)
+        --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
     -f, --filter FILTER              Selector filter for pods to be checked
@@ -138,8 +138,8 @@ Usage: ./check-kube-pods-running.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
-        --exclude-node               Exclude the specified list of nodes
-        --include-node               Include the specified list of nodes, an
+        --exclude-nodes              Exclude the specified nodes (comma separated list)
+        --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
@@ -164,8 +164,8 @@ Usage: ./check-kube-pods-restarting.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
-        --exclude-node               Exclude the specified list of nodes
-        --include-node               Include the specified list of nodes, an
+        --exclude-nodes              Exclude the specified nodes (comma separated list)
+        --include-nodes              Include the specified nodes (comma separated list), an
                                      empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Usage: check-kube-nodes-ready.rb (options)
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
         --kube-config KUBECONFIG     Path to a kube config file
+        --exclude-node               Exclude the specified list of nodes
+        --include-node               Include the specified list of nodes, an
+                                     empty list includes all nodes
 ```
 
 **check-kube-apiserver-available.rb**
@@ -70,6 +73,9 @@ Usage: check-kube-pods-pending.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
+        --exclude-node               Exclude the specified list of nodes
+        --include-node               Include the specified list of nodes, an
+                                     empty list includes all nodes
     -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
@@ -132,6 +138,9 @@ Usage: ./check-kube-pods-running.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
+        --exclude-node               Exclude the specified list of nodes
+        --include-node               Include the specified list of nodes, an
+                                     empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
         --kube-config KUBECONFIG     Path to a kube config file
@@ -155,6 +164,9 @@ Usage: ./check-kube-pods-restarting.rb (options)
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
         --include-namespace          empty list includes all namespaces
+        --exclude-node               Exclude the specified list of nodes
+        --include-node               Include the specified list of nodes, an
+                                     empty list includes all nodes
     -f, --filter FILTER              Selector filter for pods to be checked
     -p, --pods PODS                  List of pods to check
     -r, --restart COUNT              Threshold for number of restarts allowed

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -77,5 +77,4 @@ class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
     return !config[:include_node].include?(node_name) unless config[:include_node].empty?
     config[:exclude_node].include?(node_name)
   end
-
 end

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -26,9 +26,9 @@
 # -p, --password PASSWORD          If user is passed, also pass a password
 # -t, --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
-#         --exclude-node               Exclude the specified list of nodes
-#         --include-node               Include the specified list of nodes, an
-#                                      empty list includes all namespaces
+#     --exclude-node               Exclude the specified list of nodes
+#     --include-node               Include the specified list of nodes, an
+#                                  empty list includes all nodes
 #
 # LICENSE:
 #   Kel Cecil <kelcecil@praisechaos.com>

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -75,5 +75,4 @@ class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
   rescue KubeException => e
     critical 'API error: ' << e.message
   end
-
 end

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -26,8 +26,8 @@
 # -p, --password PASSWORD          If user is passed, also pass a password
 # -t, --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
-#     --exclude-node               Exclude the specified list of nodes
-#     --include-node               Include the specified list of nodes, an
+#     --exclude-nodes              Exclude the specified nodes (comma separated list)
+#     --include-nodes              Include the specified nodes (comma separated list), an
 #                                  empty list includes all nodes
 #
 # LICENSE:
@@ -41,15 +41,15 @@ require 'sensu-plugins-kubernetes/cli'
 class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
   @options = Sensu::Plugins::Kubernetes::CLI.options.dup
 
-  option :exclude_node,
-         description: 'Exclude the specified list of nodes',
-         long: '--exclude-node NODES',
+  option :exclude_nodes,
+         description: 'Exclude the specified nodes (comma separated list)',
+         long: '--exclude-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :include_node,
-         description: 'Include the specified list of nodes',
-         long: '--include-node NODES',
+  option :include_nodes,
+         description: 'Include the specified nodes (comma separated list)',
+         long: '--include-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
@@ -74,7 +74,7 @@ class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
   end
 
   def should_exclude_node(node_name)
-    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
-    config[:exclude_node].include?(node_name)
+    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
+    config[:exclude_nodes].include?(node_name)
   end
 end

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -27,6 +27,7 @@
 # -t, --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
 #     --exclude-nodes              Exclude the specified nodes (comma separated list)
+#                                  Exclude wins when a node is in both include and exclude lists
 #     --include-nodes              Include the specified nodes (comma separated list), an
 #                                  empty list includes all nodes
 #
@@ -37,9 +38,11 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/exclude'
 
 class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
   @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::Exclude
 
   option :exclude_nodes,
          description: 'Exclude the specified nodes (comma separated list)',
@@ -73,8 +76,4 @@ class AllNodesAreReady < Sensu::Plugins::Kubernetes::CLI
     critical 'API error: ' << e.message
   end
 
-  def should_exclude_node(node_name)
-    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
-    config[:exclude_nodes].include?(node_name)
-  end
 end

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -30,8 +30,8 @@
 #     --exclude-namespace
 # -i NAMESPACES,                   Include the specified list of namespaces, an
 #     --include-namespace          empty list includes all namespaces
-#     --exclude-node               Exclude the specified list of nodes
-#     --include-node               Include the specified list of nodes, an
+#     --exclude-nodes              Exclude the specified nodes (comma separated list)
+#     --include-nodes              Include the specified nodes (comma separated list), an
 #                                  empty list includes all nodes
 # -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
 # -f, --filter FILTER              Selector filter for pods to be checked
@@ -85,15 +85,15 @@ class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :exclude_node,
-         description: 'Exclude the specified list of nodes',
-         long: '--exclude-node NODES',
+  option :exclude_nodes,
+         description: 'Exclude the specified nodes (comma separated list)',
+         long: '--exclude-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :include_node,
-         description: 'Include the specified list of nodes',
-         long: '--include-node NODES',
+  option :include_nodes,
+         description: 'Include the specified nodes (comma separated list)',
+         long: '--include-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
@@ -145,7 +145,7 @@ class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
   end
 
   def should_exclude_node(node_name)
-    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
-    config[:exclude_node].include?(node_name)
+    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
+    config[:exclude_nodes].include?(node_name)
   end
 end

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -31,6 +31,7 @@
 # -i NAMESPACES,                   Include the specified list of namespaces, an
 #     --include-namespace          empty list includes all namespaces
 #     --exclude-nodes              Exclude the specified nodes (comma separated list)
+#                                  Exclude wins when a node is in both include and exclude lists
 #     --include-nodes              Include the specified nodes (comma separated list), an
 #                                  empty list includes all nodes
 # -t, --timeout TIMEOUT            Threshold for pods to be in the pending state
@@ -49,9 +50,11 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/exclude'
 
 class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
   @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::Exclude
 
   option :pod_list,
          description: 'List of pods to check',
@@ -142,10 +145,5 @@ class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
   def should_exclude_namespace(namespace)
     return !config[:include_namespace].include?(namespace) unless config[:include_namespace].empty?
     config[:exclude_namespace].include?(namespace)
-  end
-
-  def should_exclude_node(node_name)
-    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
-    config[:exclude_nodes].include?(node_name)
   end
 end

--- a/bin/check-kube-pods-restarting.rb
+++ b/bin/check-kube-pods-restarting.rb
@@ -30,6 +30,9 @@
 #        --exclude-namespace
 #    -i NAMESPACES,                   Include the specified list of namespaces, an
 #        --include-namespace          empty list includes all namespaces
+#        --exclude-node               Exclude the specified list of nodes
+#        --include-node               Include the specified list of nodes, an
+#                                     empty list includes all nodes
 #    -f, --filter FILTER              Selector filter for pods to be checked
 #    -p, --pods PODS                  List of pods to check
 #    -r, --restart COUNT              Threshold for number of restarts allowed
@@ -81,6 +84,18 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
          proc: proc { |a| a.split(',') },
          default: ''
 
+  option :exclude_node,
+         description: 'Exclude the specified list of nodes',
+         long: '--exclude-node NODES',
+         proc: proc { |a| a.split(',') },
+         default: ''
+
+  option :include_node,
+         description: 'Include the specified list of nodes',
+         long: '--include-node NODES',
+         proc: proc { |a| a.split(',') },
+         default: ''
+
   def run
     pods_list = []
     restarted_pods = []
@@ -98,6 +113,7 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
     pods.each do |pod|
       next if pod.nil?
       next if should_exclude_namespace(pod.metadata.namespace)
+      next if should_exclude_node(pod.spec.nodeName)
       next unless pods_list.include?(pod.metadata.name) || pods_list.include?('all')
       # Check restarts
       next if pod.status.containerStatuses.nil?
@@ -126,5 +142,10 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
   def should_exclude_namespace(namespace)
     return !config[:include_namespace].include?(namespace) unless config[:include_namespace].empty?
     config[:exclude_namespace].include?(namespace)
+  end
+
+  def should_exclude_node(node_name)
+    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
+    config[:exclude_node].include?(node_name)
   end
 end

--- a/bin/check-kube-pods-restarting.rb
+++ b/bin/check-kube-pods-restarting.rb
@@ -31,6 +31,7 @@
 #    -i NAMESPACES,                   Include the specified list of namespaces, an
 #        --include-namespace          empty list includes all namespaces
 #        --exclude-nodes              Exclude the specified nodes (comma separated list)
+#                                     Exclude wins when a node is in both include and exclude lists
 #        --include-nodes              Include the specified nodes (comma separated list), an
 #                                     empty list includes all nodes
 #    -f, --filter FILTER              Selector filter for pods to be checked
@@ -48,9 +49,11 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/exclude'
 
 class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
   @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::Exclude
 
   option :pod_list,
          description: 'List of pods to check',
@@ -142,10 +145,5 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
   def should_exclude_namespace(namespace)
     return !config[:include_namespace].include?(namespace) unless config[:include_namespace].empty?
     config[:exclude_namespace].include?(namespace)
-  end
-
-  def should_exclude_node(node_name)
-    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
-    config[:exclude_nodes].include?(node_name)
   end
 end

--- a/bin/check-kube-pods-restarting.rb
+++ b/bin/check-kube-pods-restarting.rb
@@ -30,8 +30,8 @@
 #        --exclude-namespace
 #    -i NAMESPACES,                   Include the specified list of namespaces, an
 #        --include-namespace          empty list includes all namespaces
-#        --exclude-node               Exclude the specified list of nodes
-#        --include-node               Include the specified list of nodes, an
+#        --exclude-nodes              Exclude the specified nodes (comma separated list)
+#        --include-nodes              Include the specified nodes (comma separated list), an
 #                                     empty list includes all nodes
 #    -f, --filter FILTER              Selector filter for pods to be checked
 #    -p, --pods PODS                  List of pods to check
@@ -84,15 +84,15 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :exclude_node,
-         description: 'Exclude the specified list of nodes',
-         long: '--exclude-node NODES',
+  option :exclude_nodes,
+         description: 'Exclude the specified nodes (comma separated list)',
+         long: '--exclude-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :include_node,
-         description: 'Include the specified list of nodes',
-         long: '--include-node NODES',
+  option :include_nodes,
+         description: 'Include the specified nodes (comma separated list)',
+         long: '--include-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
@@ -145,7 +145,7 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
   end
 
   def should_exclude_node(node_name)
-    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
-    config[:exclude_node].include?(node_name)
+    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
+    config[:exclude_nodes].include?(node_name)
   end
 end

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -32,7 +32,7 @@
 #         --include-namespace          empty list includes all namespaces
 #         --exclude-node               Exclude the specified list of nodes
 #         --include-node               Include the specified list of nodes, an
-#                                      empty list includes all namespaces
+#                                      empty list includes all nodes
 #     -f, --filter FILTER              Selector filter for pods to be checked
 #     -p, --pods PODS                  List of pods to check
 # NOTES:

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -31,6 +31,7 @@
 #     -i NAMESPACES,                   Include the specified list of namespaces, an
 #         --include-namespace          empty list includes all namespaces
 #         --exclude-nodes              Exclude the specified nodes (comma separated list)
+#                                      Exclude wins when a node is in both include and exclude lists
 #         --include-nodes              Include the specified nodes (comma separated list), an
 #                                      empty list includes all nodes
 #     -f, --filter FILTER              Selector filter for pods to be checked
@@ -46,9 +47,11 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/exclude'
 
 class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
   @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::Exclude
 
   option :pod_list,
          description: 'List of pods to check',
@@ -128,11 +131,6 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
   def should_exclude_namespace(namespace)
     return !config[:include_namespace].include?(namespace) unless config[:include_namespace].empty?
     config[:exclude_namespace].include?(namespace)
-  end
-
-  def should_exclude_node(node_name)
-    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
-    config[:exclude_nodes].include?(node_name)
   end
 
   def ready?(pod)

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -30,8 +30,8 @@
 #         --exclude-namespace
 #     -i NAMESPACES,                   Include the specified list of namespaces, an
 #         --include-namespace          empty list includes all namespaces
-#         --exclude-node               Exclude the specified list of nodes
-#         --include-node               Include the specified list of nodes, an
+#         --exclude-nodes              Exclude the specified nodes (comma separated list)
+#         --include-nodes              Include the specified nodes (comma separated list), an
 #                                      empty list includes all nodes
 #     -f, --filter FILTER              Selector filter for pods to be checked
 #     -p, --pods PODS                  List of pods to check
@@ -75,15 +75,15 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :exclude_node,
-         description: 'Exclude the specified list of nodes',
-         long: '--exclude-node NODES',
+  option :exclude_nodes,
+         description: 'Exclude the specified nodes (comma separated list)',
+         long: '--exclude-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
-  option :include_node,
-         description: 'Include the specified list of nodes',
-         long: '--include-node NODES',
+  option :include_nodes,
+         description: 'Include the specified nodes (comma separated list)',
+         long: '--include-nodes NODES',
          proc: proc { |a| a.split(',') },
          default: ''
 
@@ -131,8 +131,8 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
   end
 
   def should_exclude_node(node_name)
-    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
-    config[:exclude_node].include?(node_name)
+    return !config[:include_nodes].include?(node_name) unless config[:include_nodes].empty?
+    config[:exclude_nodes].include?(node_name)
   end
 
   def ready?(pod)

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -30,6 +30,9 @@
 #         --exclude-namespace
 #     -i NAMESPACES,                   Include the specified list of namespaces, an
 #         --include-namespace          empty list includes all namespaces
+#         --exclude-node               Exclude the specified list of nodes
+#         --include-node               Include the specified list of nodes, an
+#                                      empty list includes all namespaces
 #     -f, --filter FILTER              Selector filter for pods to be checked
 #     -p, --pods PODS                  List of pods to check
 # NOTES:
@@ -72,6 +75,18 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
          proc: proc { |a| a.split(',') },
          default: ''
 
+  option :exclude_node,
+         description: 'Exclude the specified list of nodes',
+         long: '--exclude-node NODES',
+         proc: proc { |a| a.split(',') },
+         default: ''
+
+  option :include_node,
+         description: 'Include the specified list of nodes',
+         long: '--include-node NODES',
+         proc: proc { |a| a.split(',') },
+         default: ''
+
   def run
     pods_list = []
     failed_pods = []
@@ -89,6 +104,7 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
     pods.each do |pod|
       next if pod.nil?
       next if should_exclude_namespace(pod.metadata.namespace)
+      next if should_exclude_node(pod.spec.nodeName)
       next unless pods_list.include?(pod.metadata.name) || pods_list.include?('all')
       next unless pod.status.phase != 'Succeeded' && !pod.status.conditions.nil?
       failed_pods << pod.metadata.name unless ready? pod
@@ -112,6 +128,11 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
   def should_exclude_namespace(namespace)
     return !config[:include_namespace].include?(namespace) unless config[:include_namespace].empty?
     config[:exclude_namespace].include?(namespace)
+  end
+
+  def should_exclude_node(node_name)
+    return !config[:include_node].include?(node_name) unless config[:include_node].empty?
+    config[:exclude_node].include?(node_name)
   end
 
   def ready?(pod)

--- a/lib/sensu-plugins-kubernetes/exclude.rb
+++ b/lib/sensu-plugins-kubernetes/exclude.rb
@@ -4,7 +4,6 @@ module Sensu
     module Kubernetes
       # A mixin module that provides filtering functions.
       module Exclude
-
         # Filters the list of pods or nodes based on include/exclude options.
         #
         # @option options [String] :exclude_nodes
@@ -13,21 +12,20 @@ module Sensu
         # @option options [String] :include-nodes
         #   Include the specified nodes (comma separated list), an
         #   empty list includes all nodes
-
         def node_included?(node_name)
-          if config[:include_nodes].empty? then
-            return true
+          if config[:include_nodes].empty?
+            true
           else
-            return config[:include_nodes].include?(node_name)
+            config[:include_nodes].include?(node_name)
           end
         end
 
         def node_excluded?(node_name)
-          return config[:exclude_nodes].include?(node_name)
+          config[:exclude_nodes].include?(node_name)
         end
 
         def should_exclude_node(node_name)
-          return node_excluded?(node_name) || !node_included?(node_name)
+          node_excluded?(node_name) || !node_included?(node_name)
         end
       end
     end

--- a/lib/sensu-plugins-kubernetes/exclude.rb
+++ b/lib/sensu-plugins-kubernetes/exclude.rb
@@ -1,0 +1,35 @@
+module Sensu
+  module Plugins
+    # Namespace for the Kubernetes sensu-plugin.
+    module Kubernetes
+      # A mixin module that provides filtering functions.
+      module Exclude
+
+        # Filters the list of pods or nodes based on include/exclude options.
+        #
+        # @option options [String] :exclude_nodes
+        #   Exclude the specified nodes (comma separated list)
+        #   Exclude wins when a node is in both include and exclude lists
+        # @option options [String] :include-nodes
+        #   Include the specified nodes (comma separated list), an
+        #   empty list includes all nodes
+
+        def node_included?(node_name)
+          if config[:include_nodes].empty? then
+            return true
+          else
+            return config[:include_nodes].include?(node_name)
+          end
+        end
+
+        def node_excluded?(node_name)
+          return config[:exclude_nodes].include?(node_name)
+        end
+
+        def should_exclude_node(node_name)
+          return node_excluded?(node_name) || !node_included?(node_name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

N/A

#### Purpose

Adds the ability to explicitly include or exclude nodes in check-kube-pods-pending/restarting/running, check-kube-nodes-ready. It is useful when some nodes are intentionally NotReady but we still need to check what's running on other nodes.
I've followed the pattern used in:
- #37 "ability to explicitly include namespaces"

#### Known Compatibility Issues
