### PR TITLE
fix exception when pod.spec.nodeName == nil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+ - `check-kube-nodes-ready.rb`, `check-kube-pods-pending.rb`, `check-kube-pods-restarting.rb`, `check-kube-pods-running.rb`: fix exception when pod.spec.nodeName == nil (i.e. pod not assigned to a node) (@ttarczynski)
 
 ## [3.1.0] - 2018-10-29
 ### Added

--- a/lib/sensu-plugins-kubernetes/exclude.rb
+++ b/lib/sensu-plugins-kubernetes/exclude.rb
@@ -25,7 +25,11 @@ module Sensu
         end
 
         def should_exclude_node(node_name)
-          node_excluded?(node_name) || !node_included?(node_name)
+          if node_name.nil?
+            false
+          else
+            node_excluded?(node_name) || !node_included?(node_name)
+          end
         end
       end
     end


### PR DESCRIPTION
… (i.e. pod not assigned to a node)

## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Fix an exception thrown when `pod.spec.nodeName == nil` (i.e. pod not assigned to a node).
This fix skips the `should_exclude_node` logic when `pod.spec.nodeName` is `nil`

Here's the exception trace:
```
Check failed to run: no implicit conversion of nil into String, ["/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-kubernetes-3.1.0/lib/sensu-plugins-kubernetes/exclude.rb:24:in `include?'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-kubernetes-3.1.0/lib/sensu-plugins-kubernetes/exclude.rb:24:in `node_excluded?'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-kubernetes-3.1.0/lib/sensu-plugins-kubernetes/exclude.rb:33:in `should_exclude_node'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-kubernetes-3.1.0/bin/check-kube-pods-restarting.rb:119:in `block in run'", "/opt/sensu/embedded/lib/ruby/2.3.0/delegate.rb:341:in `each'", "/opt/sensu/embedded/lib/ruby/2.3.0/delegate.rb:341:in `block in delegating_block'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-kubernetes-3.1.0/bin/check-kube-pods-restarting.rb:116:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.2/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```

#### Known Compatibility Issues
