### PR TITLE
Skip a service if its selector is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Changed
+
+ - `check-kube-service-available.rb`: Skip a service if its selector is empty. Otherwise all PODs in the cluster are listed with client.get_pods() call (including those that we do not want to monitor) (@sys-ops)
+
 ## [3.1.1] - 2018-11-01
 ### Fixed
  - `check-kube-nodes-ready.rb`, `check-kube-pods-pending.rb`, `check-kube-pods-restarting.rb`, `check-kube-pods-running.rb`: fix exception when pod.spec.nodeName == nil (i.e. pod not assigned to a node) (@ttarczynski)

--- a/bin/check-kube-service-available.rb
+++ b/bin/check-kube-service-available.rb
@@ -68,6 +68,8 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
       a.spec.selector.to_h.each do |k, v|
         selector_key << "#{k}=#{v}"
       end
+      # If selector_key is empty skip this service
+      next unless selector_key.any?
       # Get the pod
       pod = nil
       begin

--- a/bin/check-kube-service-available.rb
+++ b/bin/check-kube-service-available.rb
@@ -68,8 +68,7 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
       a.spec.selector.to_h.each do |k, v|
         selector_key << "#{k}=#{v}"
       end
-      # If selector_key is empty skip this service
-      next unless selector_key.any?
+      next if selector_key.empty?
       # Get the pod
       pod = nil
       begin


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No. However, it could be. If you check a service with an empty selector, it could alert about PODs related to another service.

#### General

- [x ] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

To avoid alerting about PODs related to another service.

#### Known Compatibility Issues

No