### PR TITLE
Fix a bug in check-kube-pods-running.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+– `check-kube-pods-running.rb`: fix "no implicit conversion of nil into String" exception when POD's status.phase == Pending (@ttarczynski)
+
 ## [4.0.0] - 2018-12-15
 ### Security
 - updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -117,7 +117,11 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
       next if should_exclude_node(pod.spec.nodeName)
       next unless pods_list.include?(pod.metadata.name) || pods_list.include?('all')
       next unless pod.status.phase != 'Succeeded' && !pod.status.conditions.nil?
-      pod_stamp = Time.parse(pod.status.startTime)
+			if pod.status.phase == 'Pending'
+				pod_stamp = Time.parse(pod.metadata.creationTimestamp)
+			else
+				pod_stamp = Time.parse(pod.status.startTime)
+			end
       runtime = (Time.now.utc - pod_stamp.utc).to_i
       next if runtime < config[:not_ready_time]
       failed_pods << pod.metadata.name unless ready? pod


### PR DESCRIPTION
## Pull Request Checklist

/fix #68 

#### General

- [x] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

#### Purpose

It's a bug fix for:
#68 – check-kube-pods-running.rb - no implicit conversion of nil into String 
The "no implicit conversion of nil into String" error occurs when there are PODs in Pending state

#### Known Compatibility Issues
