### PR TITLE
set frozen_string_literal false for executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Fixed frozen_string_literal setting in executables
 
 ## [5.0.1] - 2020-04-27
 ### Changed

--- a/bin/check-kube-apiserver-available.rb
+++ b/bin/check-kube-apiserver-available.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-apiserver-available.rb
 #

--- a/bin/check-kube-nodes-ready.rb
+++ b/bin/check-kube-nodes-ready.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-nodes-ready.rb
 #

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-pods-pending
 #

--- a/bin/check-kube-pods-restarting.rb
+++ b/bin/check-kube-pods-restarting.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-pods-restarting
 #

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-pods-running
 #

--- a/bin/check-kube-pods-runtime.rb
+++ b/bin/check-kube-pods-runtime.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-pods-runtime
 #

--- a/bin/check-kube-service-available.rb
+++ b/bin/check-kube-service-available.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   check-kube-pods-service-available
 #

--- a/bin/handler-kube-pod.rb
+++ b/bin/handler-kube-pod.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   handler-kube-pod
 #

--- a/bin/metrics-pods.rb
+++ b/bin/metrics-pods.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #   pod-metrics
 #


### PR DESCRIPTION
## Pull Request Checklist


#### General

- [X] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] RuboCop passes

- [x] Existing tests pass

#### Purpose
Fix the frozen_string_literal setting in the executables under bin/

