### PR TITLE
check-kube-service-available: Add --ignore-evicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- `check-kube-service-available.rb`: added `--ignore-evicted` which will ignore pods that are in the Evicted state (@dave-shawley)
 
 ## [5.0.2] - 2020-09-15
 ### Fixed


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** no.

#### General

- [X] Update Changelog following the conventions laid out at [here ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets (**N/A**)

- [X] Binstubs are created if needed (**N/A**)

- [ ] RuboCop passes -- _I don't have a fully functional ruby environment currently_

- [ ] Existing tests pass -- _I don't have a fully functional ruby environment currently_

#### New Plugins

- [X] Tests (**N/A**)

- [X] Add the plugin to the README (**N/A**)

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style) (**N/A**)

#### Purpose

Our cluster occasionally has pods stuck in the evicted state even though the service is running fine.  Adding a CLI option that ignores evicted pods makes the check less noisy.

#### Known Compatibility Issues
